### PR TITLE
`kafka-manager` now requires `password` (`username` defaults to `admin`) for basic authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ export BOSH_ENVIRONMENT=<bosh-alias>
 export BOSH_DEPLOYMENT=kafka
 git clone https://github.com/cloudfoundry-community/kafka-boshrelease.git
 bosh deploy kafka-boshrelease/manifests/kafka.yml \
-  -o <(kafka-boshrelease/manifests/operators/pick-from-cloud-config.sh)
+  -o <(kafka-boshrelease/manifests/operators/pick-from-cloud-config.sh kafka-boshrelease/manifests/kafka.yml)
 ```
 
 If your BOSH does not have Credhub/Config Server, then remember `--vars-store` to allow generation of passwords and certificates.
@@ -22,7 +22,7 @@ You can pre-define some simple topics using an operator script `./manifests/oper
 
 ```
 bosh deploy kafka-boshrelease/manifests/kafka.yml \
-  -o <(kafka-boshrelease/manifests/operators/pick-from-cloud-config.sh) \
+  -o <(kafka-boshrelease/manifests/operators/pick-from-cloud-config.sh kafka-boshrelease/manifests/kafka.yml) \
   -o <(kafka-boshrelease/manifests/operators/simple-topics.sh test1 test2)
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ export BOSH_ENVIRONMENT=<bosh-alias>
 export BOSH_DEPLOYMENT=kafka
 git clone https://github.com/cloudfoundry-community/kafka-boshrelease.git
 bosh deploy kafka-boshrelease/manifests/kafka.yml \
-  -o <(manifests/operators/pick-from-cloud-config.sh)
+  -o <(kafka-boshrelease/manifests/operators/pick-from-cloud-config.sh)
 ```
 
 If your BOSH does not have Credhub/Config Server, then remember `--vars-store` to allow generation of passwords and certificates.
@@ -22,8 +22,8 @@ You can pre-define some simple topics using an operator script `./manifests/oper
 
 ```
 bosh deploy kafka-boshrelease/manifests/kafka.yml \
-  -o <(manifests/operators/pick-from-cloud-config.sh) \
-  -o <(manifests/operators/simple-topics.sh test1 test2)
+  -o <(kafka-boshrelease/manifests/operators/pick-from-cloud-config.sh) \
+  -o <(kafka-boshrelease/manifests/operators/simple-topics.sh test1 test2)
 ```
 
 ### Kafka Manager
@@ -33,8 +33,10 @@ bosh deploy kafka-boshrelease/manifests/kafka.yml \
 The [Yahoo Kafka Manager](https://github.com/yahoo/kafka-manager) UI is installed on each Kafka node. You can access it via port 8080. To access via http://localhost:8080, open a tunnel:
 
 ```
-bosh ssh kafka/0 -- -L 8080:127.0.0.1:8080
+bosh ssh kafka-manager/0 -- -L 8080:127.0.0.1:8080
 ```
+
+Kafka Manager requires basic auth credentials. The default `username` is `admin`, and the `password` is the `((kafka-manager-password))` value from either Credhub/Config Server, or your `--vars-store creds.yml` file.
 
 ### Update
 

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,1 @@
+* `kafka-manager` now requires `password` (`username` defaults to `admin`) for basic authentication. A `((kafka-manager-password))` variable has been added to the two base manifests.

--- a/jobs/kafka-manager/spec
+++ b/jobs/kafka-manager/spec
@@ -26,3 +26,9 @@ properties:
   name:
     description: "Name given to cluster when it is automatically registered"
     default: BOSH
+
+  username:
+    description: Basic auth credentials
+    default: admin
+  password:
+    description: Basic auth credentials

--- a/jobs/kafka-manager/templates/config/application.conf
+++ b/jobs/kafka-manager/templates/config/application.conf
@@ -34,9 +34,9 @@ akka {
   loglevel = "INFO"
 }
 
-basicAuthentication.enabled=false
-basicAuthentication.username="admin"
-basicAuthentication.password="password"
+basicAuthentication.enabled=true
+basicAuthentication.username="<%= p('username') %>"
+basicAuthentication.password="<%= p('password') %>"
 basicAuthentication.realm="Kafka-Manager"
 
 

--- a/manifests/kafka-solo.yml
+++ b/manifests/kafka-solo.yml
@@ -24,9 +24,13 @@ instance_groups:
     properties: {}
   - name: kafka-manager
     release: kafka
-    properties: {}
+    properties:
+      username: admin
+      password: ((kafka-manager-password))
 
-variables: []
+variables:
+- name: kafka-manager-password
+  type: password
 
 stemcells:
 - alias: default

--- a/manifests/kafka.yml
+++ b/manifests/kafka.yml
@@ -34,11 +34,23 @@ instance_groups:
   - name: kafka
     release: kafka
     properties: {}
+- name: kafka-manager
+  azs: [z1, z2, z3]
+  instances: 1
+  vm_type: default
+  stemcell: default
+  persistent_disk: 10240
+  networks: [{name: default}]
+  jobs:
   - name: kafka-manager
     release: kafka
-    properties: {}
+    properties:
+      username: admin
+      password: ((kafka-manager-password))
 
-variables: []
+variables:
+- name: kafka-manager-password
+  type: password
 
 stemcells:
 - alias: default

--- a/manifests/operators/pick-from-cloud-config.sh
+++ b/manifests/operators/pick-from-cloud-config.sh
@@ -13,7 +13,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR/../..
 
-instance_groups=$(bosh int <(cat manifests/*.yml) $@ --path /instance_groups | grep "^  name:" | awk '{print $2}' | sort | uniq)
+instance_groups=$(bosh int "$@" --path /instance_groups | grep "^  name:" | awk '{print $2}' | sort | uniq)
 cloud_config=$(bosh cloud-config)
 if [[ -z ${cloud_config} ]]; then
   echo "BOSH env missing a cloud-config"


### PR DESCRIPTION
`kafka-manager` now requires `password` (`username` defaults to `admin`) for basic authentication.
A `((kafka-manager-password))` variable has been added to the two base manifests.
