### PR TITLE
Make internal topic settings configurable

### DIFF
--- a/jobs/kafka/spec
+++ b/jobs/kafka/spec
@@ -42,3 +42,15 @@ properties:
   delete_topic:
     description: "Switch to enable topic deletion or not"
     default: false
+
+  offsets.topic.replication.factor:
+    description: "The replication factor for the offsets topic"
+    default: 3
+
+  transaction.state.log.replication.factor:
+    description: "The replication factor for the transaction topic"
+    default: 3
+
+  transaction.state.log.min.isr:
+    description: "Overridden min.insync.replicas config for the transaction topic"
+    default: 2

--- a/jobs/kafka/templates/config/server.properties
+++ b/jobs/kafka/templates/config/server.properties
@@ -67,6 +67,13 @@ num.partitions=1
 # This value is recommended to be increased for installations with data dirs located in RAID array.
 num.recovery.threads.per.data.dir=1
 
+############################# Internal Topic Settings  #############################
+# The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
+# For anything other than development testing, a value greater than 1 is recommended for to ensure availability such as 3.
+offsets.topic.replication.factor=<%= p("offsets.topic.replication.factor") %>
+transaction.state.log.replication.factor=<%= p("transaction.state.log.replication.factor") %>
+transaction.state.log.min.isr=<%= p("transaction.state.log.min.isr") %>
+
 ############################# Log Flush Policy #############################
 
 # Messages are immediately written to the filesystem but by default we only fsync() to sync

--- a/jobs/sanity-test/templates/bin/run
+++ b/jobs/sanity-test/templates/bin/run
@@ -24,5 +24,5 @@ mkdir -p $testpath
 set -x
 kafka-topics.sh --zookeeper $zk_peers --create --if-not-exists --replication-factor 1 --partitions 1 --topic test > $testpath/demo.out
 echo "test message" | kafka-console-producer.sh --broker-list $kafka_hosts --topic test 2>/dev/null 
-kafka-console-consumer.sh --zookeeper $zk_peers --topic test --from-beginning --max-messages 1 >> $testpath/demo.out 2>/dev/null
+kafka-console-consumer.sh --bootstrap-server $kafka_hosts --topic test --from-beginning --max-messages 1 >> $testpath/demo.out 2>/dev/null
 kafka-topics.sh --zookeeper $zk_peers --delete --topic test >> $testpath/demo.out 2>/dev/null

--- a/manifests/kafka-solo.yml
+++ b/manifests/kafka-solo.yml
@@ -21,7 +21,18 @@ instance_groups:
     properties: {}
   - name: kafka
     release: kafka
-    properties: {}
+    properties:
+      offsets:
+        topic:
+          replication:
+            factor: 1
+      transaction:
+        state:
+          log:
+            replication:
+              factor: 1
+            min:
+              isr: 1
   - name: kafka-manager
     release: kafka
     properties:

--- a/manifests/kafka.yml
+++ b/manifests/kafka.yml
@@ -33,7 +33,18 @@ instance_groups:
   jobs:
   - name: kafka
     release: kafka
-    properties: {}
+    properties:
+      offsets:
+        topic:
+          replication:
+            factor: 1
+      transaction:
+        state:
+          log:
+            replication:
+              factor: 1
+            min:
+              isr: 1
 - name: kafka-manager
   azs: [z1, z2, z3]
   instances: 1


### PR DESCRIPTION
"Internal Topic Settings" part is missing in `jobs/kafka/templates/config/server.properties`.

In `/var/vcap/packages/kafka/config/server.properties`,  internal topic settings are following:

``` properties
############################# Internal Topic Settings  #############################
# The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
# For anything other than development testing, a value greater than 1 is recommended for to ensure availability such as 3.
offsets.topic.replication.factor=1
transaction.state.log.replication.factor=1
transaction.state.log.min.isr=1
```

The [default values](https://kafka.apache.org/documentation/#brokerconfigs) of these properties are
* `offsets.topic.replication.factor`: 3
* `transaction.state.log.replication.factor`: 3
* `transaction.state.log.min.isr`: 2

`offsets.topic.replication.factor` is 3 if this bosh-release is used.
This means creating `__consumer_offsets` topic requires 3 alive brokers.
So `kafka-console-consumer.sh --bootstrap-server <kafka urls>` (not old style `kafka-console-consumer.sh --zookeeper <zk urls>`) can't consume messages if the number of kafka is 1. 

Error message:
```
[2018-04-29 19:30:10,027] ERROR [KafkaApi-1] Number of alive brokers '1' does not meet the required replication factor '3' for the offsets topic (configured via 'offsets.topic.replication.factor'). This error can be ignored if the cluster is starting up and not all brokers are up yet. (kafka.server.KafkaApis)
```

This  pull request makes internal topic settings above configurable and leaves default values same as kafka's default so that this won't make a breaking change.