### PR TITLE
Optionally attach Jolokia JVM Agent for Telegraf support

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,3 +1,6 @@
+jolokia-jvm-1.6.0-agent.jar:
+  size: 461859
+  sha: aff25a0452cf22dc85cbc96e0f149bbc2e4adb64
 kafka/kafka-manager-1.3.3.4.zip:
   size: 60436159
   object_id: fb58fb86-6852-4fcd-484b-e708125b5ba7

--- a/jobs/kafka/spec
+++ b/jobs/kafka/spec
@@ -54,3 +54,7 @@ properties:
   transaction.state.log.min.isr:
     description: "Overridden min.insync.replicas config for the transaction topic"
     default: 2
+
+  jolokia.enabled:
+    description: "Enable Jolokia JVM Agent"
+    default: false

--- a/jobs/kafka/templates/bin/ctl
+++ b/jobs/kafka/templates/bin/ctl
@@ -13,6 +13,9 @@ done
 export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:/var/vcap/jobs/kafka/config/log4j.properties"
 export LOG_DIR=/var/vcap/sys/log/kafka
 export JMX_PORT="<%= p("jmx_port") %>"
+<% if p("jolokia.enabled") %>
+export EXTRA_ARGS="-javaagent:/var/vcap/packages/jolokia/jolokia-jvm-1.6.0-agent.jar"
+<% end %>
 
 case $1 in
 

--- a/packages/jolokia/packaging
+++ b/packages/jolokia/packaging
@@ -1,0 +1,3 @@
+set -e -u
+
+cp jolokia-jvm-1.6.0-agent.jar ${BOSH_INSTALL_TARGET}/

--- a/packages/jolokia/spec
+++ b/packages/jolokia/spec
@@ -1,0 +1,5 @@
+---
+name: jolokia
+dependencies: []
+files:
+- jolokia-jvm-1.6.0-agent.jar


### PR DESCRIPTION
**Problem**
Kafka provides many metrics which are exposed with JMX ([Kafka Monitoring Docs](https://kafka.apache.org/documentation/#monitoring)). In our environment we are making heavy use of Telegraf, with which reading the JMX metrics is not easily possible (see also PR [#3609](https://github.com/influxdata/telegraf/issues/3609) regarding that).

**Proposal**
Optionally provide metrics with (Jolokia JVM Agent)[https://jolokia.org/download.html], which can then easily be read with the Telegraf Jolokia 2 input plugin ([example](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/jolokia2/examples/kafka.conf)).