### PR TITLE
Add manual and Auto configuration KAFKA_HEAP_OPTS

### DIFF
--- a/jobs/kafka/spec
+++ b/jobs/kafka/spec
@@ -42,6 +42,9 @@ properties:
     description: "The port to listen for JMX connections, disabled by default"
     default: ''
 
+  heap_size:
+    description: "set KAFKA_HEAP_OPTS"
+
   topics:
     default: []
     description: |-

--- a/jobs/kafka/templates/bin/ctl
+++ b/jobs/kafka/templates/bin/ctl
@@ -13,6 +13,14 @@ done
 <% if p("enable_sasl_scram") %>
 export KAFKA_OPTS="-Djava.security.auth.login.config=/var/vcap/jobs/kafka/config/kafka_server_jaas.conf"
 <% end %>
+
+export HEAP_SIZE=$((( $( cat /proc/meminfo | grep MemTotal | awk '{ print $2 }' ) * 46 ) / 100 ))K
+
+<% if_p('heap_size') do |heap_size| %>
+HEAP_SIZE=<%= heap_size %>
+<% end %>
+
+export KAFKA_HEAP_OPTS="-Xms${HEAP_SIZE} -Xmx${HEAP_SIZE}"
 export KAFKA_LOG4J_OPTS="-Dlog4j.configuration=file:/var/vcap/jobs/kafka/config/log4j.properties"
 export LOG_DIR=/var/vcap/sys/log/kafka
 export JMX_PORT="<%= p("jmx_port") %>"

--- a/manifests/operators/custom-heap.yml
+++ b/manifests/operators/custom-heap.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=kafka/jobs/name=kafka/properties/heap_size?
+  value: ((heap_size))


### PR DESCRIPTION
default heap setting is 1g.
I inspired by [bosh-elastic-stack/elasticsearch-boshrelease](https://github.com/bosh-elastic-stack/elasticsearch-boshrelease).